### PR TITLE
Allow upload of yarn.lock files

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Currently VersionEye supports various package managers. You can throw any of thi
  - Podfile 
  - Podfile.lock 
  - package.json 
+ - yarn.lock 
  - composer.json 
  - composer.lock
  - bower.json 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -36,6 +36,7 @@ module.exports = {
      */
     allowedProjectFiles: [
         'package.json', // NPM (Node.JS)
+        'yarn.lock' // Yarn (Node.JS)
         'bower.json', // Bower (JavaScript)
         'Gemfile', // Bundler (Ruby)
         'Gemfile.lock',


### PR DESCRIPTION
VersionEye now also supports `yarn.lock` files.

https://github.com/versioneye/versioneye-core/issues/57